### PR TITLE
Add paper_writing/ docs (second brain for EMNLP paper)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ formalized_graph_v2/**/*.olean
 formalized_graph_v2/**/*.ilean
 formalized_graph_v2/**/__pycache__/
 formalized_graph/data/
+
+# External reference clones used for paper-writing comparisons (not vendored).
+formalized_graph/docs/paper_writing/leansearch_v2_external/

--- a/formalized_graph/docs/paper_writing/README.md
+++ b/formalized_graph/docs/paper_writing/README.md
@@ -1,0 +1,42 @@
+# paper_writing/ — second brain for the EMNLP paper
+
+This directory exists to offload every paper-relevant fact (schemas, sample
+rows, API surfaces, scale numbers, experiment summaries, related-work
+comparisons) into terse markdown so future sessions can ground themselves
+without re-deriving anything from the live system.
+
+## Contents
+
+| file | purpose |
+|---|---|
+| [`schema.md`](./schema.md) | v2 RDS table schemas, in data-flow order (paper → statement → metadata → slogan → embedding), with one-paragraph explainers. |
+| [`samples.md`](./samples.md) | Two real rows per table, chosen so embedding / `lean` / `decl_name` / `docstring` are populated. Embedding vectors shown as `<dim, norm, head, tail>`. |
+| [`api_reference.md`](./api_reference.md) | Thin pointer to `api/README.md` (canonical) plus paper-writing-relevant gotchas (e.g. legacy `/search` integer-IDs are not graph-addressable). |
+| [`leansearch_v2_comparison.md`](./leansearch_v2_comparison.md) | Working notes comparing our corpus + pipeline against LeanSearch v2. |
+
+## Contributor prompt
+
+Copy/paste this when bringing a new model into the work:
+
+> You are contributing to `formalized_graph/docs/paper_writing/` — a
+> "second brain" for the EMNLP paper. The goal is to offload every
+> paper-relevant fact (schemas, sample rows, API surfaces, scale numbers,
+> experiment summaries) into terse markdown so future sessions can ground
+> themselves without re-deriving anything from the live system.
+>
+> Before answering or writing:
+>
+> 1. Read every file in this directory. Cross-reference with the canonical
+>    sources they point to (e.g. `api_reference.md` points to
+>    `api/README.md`).
+> 2. Ground new claims in the live RDS (db `v2` on
+>    `theorem-search.cluster-cx0ei6kq0qcn.us-west-2.rds.amazonaws.com`)
+>    or the repo code — never invent numbers or schema details.
+> 3. Prefer adding a new short file or extending an existing one over
+>    long prose. Link between files with relative paths.
+>
+> Style: terse, factual, table-heavy. No narrative. No restating things
+> already documented in repo CLAUDE.md or `api/README.md` — link to them.
+>
+> Ask before assuming. If a fact looks stale, verify against the DB or
+> code and update in place rather than appending duplicates.

--- a/formalized_graph/docs/paper_writing/api_reference.md
+++ b/formalized_graph/docs/paper_writing/api_reference.md
@@ -1,0 +1,35 @@
+# API Reference (paper-writing lens)
+
+**Canonical doc:** [`api/README.md`](../../../api/README.md). Read that first — it covers every endpoint, params, response shape, `mode=full|minimal`, and the `return=representations` opt-in.
+
+> **Agents:** fetch `api/README.md` from the repo root (relative path `../../../api/README.md`) for the full API definitions — they are not duplicated here.
+
+This file just records the bits that are paper-relevant but not in the API README.
+
+---
+
+## Endpoint ↔ paper section mapping
+
+| Endpoint | Paper claim it supports |
+|---|---|
+| `GET /graph/embedding` | NL → corpus retrieval. Same two-phase pattern as the blueprint experiment (binary-quantized HNSW shortlist → full-precision cosine rerank). The numbers in `experiments/blueprint_matching/q1.txt`–`q2.txt` come from this exact code path. |
+| `GET /graph/statement/{id}?direction=both` | Local graph structure. Edge annotations (`location`, `methods`, `edge_type`) are the per-edge provenance you can cite when explaining how `informal_dependency` and `formal_dependency` were built. |
+| `GET /graph/statement/{id}?return=representations` | **Q4 of the blueprint experiment, productionised.** Returns cross-paper semantic neighbours above cosine ≥ 0.8 (constant `_REPRESENTATION_SIMILARITY_THRESHOLD` in `api/routes/graph.py`), always from a *different* `paper_id`. If the paper claims "we surface restatements / equivalent results across the corpus," this is the endpoint that does it. |
+| `GET /graph/paper` | Whole-paper subgraph — useful for figures/case-studies in the paper. Auto-switches between informal (`informal_dependency`) and formal (`formal_dependency`) based on `paper.kind == 'lean_repo'`. |
+
+---
+
+## The legacy `POST /search` surface (not in api/README)
+
+Still deployed at `api.theoremsearch.com/search` and behind `/mcp`. Queries the **flat `theorem_search_qwen8b` table** with integer `theorem_id` / `slogan_id` and string `paper_id` like `"1909.00474v2"`.
+
+**Do not cite `/search` in the paper unless you're explicitly contrasting the prod search surface with the graph surface** — the ID space is incompatible with everything under `/graph/*` and with the `v2` schema documented in [`schema.md`](./schema.md). The graph experiments and the new API both use UUID `statement_id` from the `statement` table.
+
+---
+
+## Cross-references
+
+- Tables and column types behind these endpoints: [`schema.md`](./schema.md).
+- Real sample rows (incl. an `embedding` row showing dim/norm/head/tail): [`samples.md`](./samples.md).
+- Embedding pipeline + dimension/norm details: `embedding_model` row in `samples.md` (qwen3-8b, dim=4096, instruction-prefixed at embed time).
+- Blueprint-matching experiment that mirrors the production retrieval: `experiments/blueprint_matching/` (q1–q4).

--- a/formalized_graph/docs/paper_writing/leansearch_v2_comparison.md
+++ b/formalized_graph/docs/paper_writing/leansearch_v2_comparison.md
@@ -1,0 +1,207 @@
+# LeanSearch v2 vs. ours — comparison for paper writing
+
+Status: working notes. All "ours" claims grounded in `schema.md` / `samples.md`
+/ `api/README.md`. All "LSv2" claims grounded in `leansearch_v2_external/`
+(README, `src/leansearchv2/`, `benchmark/`) and arXiv:2605.13137v2.
+
+---
+
+## 1. Scope of corpus
+
+| | LeanSearch v2 | Ours (v2 schema) |
+|---|---|---|
+| Sources | Mathlib only, single revision (v4.28.0-rc1) | arXiv (1,841,292 papers), Lean Community blueprints (21 repos), Lean repos (30) |
+| Side | Formal only | Both: 12,137,642 statements total; 388,105 with `formality=formal`; rest informal |
+| Filter | User-facing kinds: `theorem`, `definition`, `instance`, `abbrev`, `opaque`, `axiom`; drops `_proof_1` / `match_*` (`is_internal`); inductive/structure/class kept *for informalization context* but not exported | All statements retained regardless of kind; `kind` is a free-text column |
+| Cross-formality bridge | None — formal world only | `informal_metadata.lean` is the blueprint `\lean{...}` annotation; populated rows give ground-truth informal-↔-formal pairs (e.g. `Real.marcinkiewicz_zygmund', Real.marcinkiewicz_zygmund`) |
+| Corpus size shipped | Pre-built cuVS index on HuggingFace; exact decl count not disclosed in paper | 12.1M statements, 16.5M slogans, 12.1M embeddings |
+
+**Headline:** LSv2 is a *narrow, deep* Mathlib-only corpus; ours is a *broad,
+shallow-on-Lean-side* multi-source corpus where the blueprint subset is the
+analogue of theirs and the arXiv subset is unique to us.
+
+---
+
+## 2. Corpus construction pipeline
+
+| Stage | LSv2 (`src/leansearchv2/corpus/`) | Ours |
+|---|---|---|
+| Static extraction | `jixia` (Lean static analyzer, submoduled at v4.28.0-rc1) → raw per-file JSON | Lean elaborator extract for Lean repos; regex parser for arXiv (`arxiv_parse_status.parsing_method='regex'`) |
+| Merge | `merge_to_jsonl.py` — flatten + resolve refs | Loaded into Postgres `statement` + `formal_metadata` / `informal_metadata` |
+| Dependency graph | Built internally during informalization: `typeReferences` (+ `valueReferences` for non-Prop), topo-sort via Kahn's algorithm, bottom-up | Persisted as first-class tables: `informal_dependency` (18.3M rows) and `formal_dependency` (11.3M rows) with edge-type annotations |
+| Informalization | Kind-specific Jinja templates (`theorem.md.j2`, `definition.md.j2`, `instance.md.j2`, `technical_entry.md.j2`); Qwen3-32B (Gemini 2.5 Pro fallback); each prompt receives dep summaries | Per-statement *slogans* via `slogan_prompt` × `slogan_model` registry (8 prompts × 2 models = 16 supported configs; current: `minimal`, `formal` prompts on `qwen3-235b` and `pilot-claude-sonnet-4-6`); `comprehensive` prompt uses `informal_dependency.methods` as trust score |
+| Embedding | Qwen3-Embedding-8B (dim 4096, normalized); single embedding per declaration | Same model. Multiple embeddings per statement (one per slogan), excluding `insufficient_context=true` |
+| Index | cuVS CAGRA, built with `intermediate_graph_degree=128`, `graph_degree=64`, `build_algo=ivf_pq`, metric=cosine; search `itopk_size=1024`, `search_width=4` | pgvector: binary-quantized HNSW on `bit(4096)` for shortlist; full-precision `vector(4096)` cosine for rerank |
+| Reranker | Qwen3-Reranker-8B (paper) / 4B (public deployment) cross-encoder; binary `yes`/`no` token logit softmax | None LM-based. Score = cosine + `citation_weight × ln(citations)` for `/graph/embedding` |
+
+**Headline:** LSv2's pipeline is a *clean linear ETL* terminating in a flat
+index. Ours persists the dep graph and supports *multiple slogans per
+statement* — a many-to-one between embeddings and source statements that
+LSv2 doesn't have.
+
+---
+
+## 3. Retrieval API surface
+
+### LSv2 `POST /search` (`src/leansearchv2/server.py`)
+
+```jsonc
+// Request
+{ "query": ["..."], "num_results": 10, "rerank": true, "retrieve_k": null }
+
+// Response — list[list[SearchResult]]
+[[ { "result": { "module_name": [...], "kind": "theorem", "name": [...],
+                 "signature": "...", "type": "...", "value": null,
+                 "docstring": "...", "informal_name": "...",
+                 "informal_description": "..." },
+     "distance": 0.123 } ]]
+```
+
+Three endpoints total: `POST /search`, `POST /search_with_profile`, `GET /health`.
+No graph traversal. No cross-paper notion (corpus is single-corpus). No filters
+by author/citations/date/source. The instruction string is hard-coded into the
+pipeline (see `RetrievalPipeline.INSTRUCTION`).
+
+### Ours `/graph/*` (`api/README.md`)
+
+Three endpoints: `/graph/embedding`, `/graph/statement/{id}`, `/graph/paper`.
+
+- `GET /graph/embedding` — NL retrieval analogous to LSv2's `/search`. Adds
+  filters: `sources`, `types`, `authors`, `min_citations`, `in_journal`,
+  `citation_weight`. Two-phase binary→full cosine. UUID `statement_id`.
+- `GET /graph/statement/{id}` — what LSv2 has no analogue of: one-hop graph
+  walk in `direction ∈ {src, dep, both}`, choice of `formality ∈ {informal,
+  formal}`. Edge payload includes provenance (`methods`, `location`, or
+  `edge_type`). Opt-in `return=representations` adds cross-paper semantic
+  neighbours at cosine ≥ 0.8 from a *different* `paper_id`.
+- `GET /graph/paper` — whole-paper subgraph; auto-switches informal vs.
+  formal edges based on `paper.kind == 'lean_repo'`.
+
+**Headline:** LSv2 is a *single-shot retriever*; ours is a *retrieval + graph
+navigator*. The closest LSv2 has to our `representations` is none — they
+return a flat hit list and stop.
+
+---
+
+## 4. Reranking / reasoning beyond retrieval
+
+| | LSv2 | Ours |
+|---|---|---|
+| Cross-encoder rerank | Qwen3-Reranker-8B, P(yes) over yes/no tokens; default `retrieve_k = max(top_k×2, 50)` | None |
+| Score boost | None | `citation_weight × ln(citation_count)` on `/graph/embedding` |
+| Iterative loop | Reasoning mode: decompose → search → filter → judge, ≤3 revision rounds. Sonnet 4.5 for sketch / judge / revision, Kimi K2 for filter | None in core API. Possible to build externally by chaining `/graph/embedding` + `/graph/statement` |
+| Output of reasoning | Premise *groups* — sets of interchangeable lemmas that jointly support a proof | N/A. We expose dependency edges directly; "what would prove this theorem" is not a first-class call |
+
+---
+
+## 5. Benchmarks shipped
+
+### LSv2 (`leansearch_v2_external/benchmark/`)
+
+| File | Rows | What it is |
+|---|---|---|
+| `MathlibQR.json` | 200 decls × up to 6 query styles = **946 populated query rows** (1200 cells, 254 empty) | Single-query retrieval eval. Styles: `q1a_lean` (Lean-flavored), `q1b_latex`, `q1c_natural` (plain English), `q2_slogan`, `q3_nickname`, `q4_special_case`. Difficulty 101 Easy / 99 Hard. Kinds: theorem 74, structure 39, class 29, def 26, instance 25, inductive 6, lemma 1. |
+| `MathlibQR_shared171.json` | 171 decls = 810 fair-subset queries | Subset present across all systems' corpora (handles Mathlib version skew across competitors). |
+| `MathlibMPR.json` | **69 theorems**, 204 premise groups total (171 `original` + 33 `alternative`), mean **2.96 groups/query**, 1–8 groups, mean **1.75 lemmas/group**, 1–6 | Global premise retrieval eval. Sourced from merged Mathlib PRs (`pr` field). Schema: `id`, `pr`, `formal_main_result`, `NL_main_result`, `formal_statement` (with `sorry`), `premise_group: [{kind, docs}]`. |
+| `MathlibMPR_Prop_ids.txt` | 50 ids | Prop-only subset for downstream prove eval. |
+| `FATE-H.jsonl` | 100 problems | External: redistributed under CC-BY-4.0 from FATE paper (Jiang et al. 2025). Schema: `informal_statement`, `formal_statement` (with `by`), `informal_proof`, `tag`, `name`. |
+
+### Ours
+
+- `experiments/blueprint_matching/` — q1–q4 numbers per `api_reference.md`,
+  driven by the `informal_metadata.lean` ground-truth bridge between
+  blueprint informal statements and Mathlib `decl_name`s. *I have not yet
+  read the q*.txt outputs in this comparison pass; flag this gap.*
+- No published equivalent of MathlibMPR (premise groups). Our
+  `formal_dependency` rows are the raw material a premise-group benchmark
+  could be built from, but we ship no curated eval set today.
+
+**Headline:** LSv2 ships **two** purpose-built benchmarks (MathlibQR for
+single-query retrieval; MathlibMPR for global premise) plus a borrowed
+prover benchmark (FATE-H). Ours ships the bridge data (`informal_metadata.lean`)
+but no benchmark file under version control with the same first-class status.
+
+---
+
+## 6. Evaluation metrics
+
+| Metric | LSv2 | Ours equivalent |
+|---|---|---|
+| nDCG@10 (Table 1) | LSv2 rerank **0.623**; LeanFinder 0.533 | Not reported in same form. Blueprint q1–q4 in `experiments/blueprint_matching` use recall@k against `informal_metadata.lean` ground truth — not directly comparable. |
+| Recall@10(group) (Table 2) | LSv2 reasoning **46.1%**; DIVER 38.0%; LeanStateSearch 9.3% | No premise-group concept persisted; would need to derive groups from `formal_dependency` first. |
+| Covered@k (Table 2) | LSv2 reasoning 30.4% | None. |
+| Proof success (Table 3, FATE-H × fixed prover loop) | LSv2 reasoning **20%**; INF-X-Retriever 16%; no-retrieval 4%. MathlibMPR-Prop: LSv2 reasoning 14% | None — we have no prover pipeline. |
+
+---
+
+## 7. What we should claim in the paper (and what we shouldn't)
+
+**Where we win or are differentiated:**
+- *Cross-formality bridge.* `informal_metadata.lean` is a ground-truth
+  informal↔formal link that LSv2 has no analogue of (their corpus is
+  formal-only).
+- *Multi-source scope.* 1.84M arXiv papers + Lean blueprints + Lean repos
+  vs. Mathlib-only. The arXiv side is unique.
+- *Persisted dependency graph.* Edges are queryable (`edge_type`, `methods`,
+  `location`, ranker-grade `position`/`binder`/`role` on signatures);
+  LSv2 builds a dep DAG internally but throws it away after corpus build.
+- *Many-slogans-per-statement.* Lets us study prompt/model sensitivity
+  (`slogan_prompt` × `slogan_model`) on retrieval; LSv2 fixes one
+  informalization per decl.
+- *Cross-paper restatement surface* via `/graph/statement/{id}?return=representations` (cosine ≥ 0.8, different `paper_id`). LSv2 has no cross-paper notion because there is only one paper (Mathlib).
+
+**Where LSv2 is ahead and the paper needs to acknowledge / address:**
+- *Reranker.* No LM cross-encoder rerank in our pipeline. On the same
+  retrieval shortlist they would beat us in nDCG.
+- *Reasoning loop.* Decompose-search-filter-judge for global premise retrieval
+  with 46.1% Recall@10(group). We have no iterative loop in the API today.
+- *Curated benchmarks.* MathlibQR (200 decls × 6 styles) and MathlibMPR (69
+  theorems with premise groups) are reusable artifacts. Our `blueprint_matching`
+  experiment is an in-house eval, not a benchmark file the community can drop
+  into a leaderboard.
+- *Downstream prove eval.* They tie retrieval quality to a fixed prover loop;
+  we don't.
+
+**Specifically do NOT claim:**
+- That we exceed their nDCG@10 — we have not measured against MathlibQR.
+- That `/graph/embedding` is "the same" pipeline. Differences: pgvector
+  binary-HNSW vs. cuVS CAGRA; no LM reranker; multiple slogans per
+  statement; cross-source filters.
+- That our slogans match their informalization template format. Ours are
+  natural-language summaries (1–4 sentences, ASCII). Theirs is a
+  multi-field template (`informal_name`, `informal_description`) bundled
+  with the Lean signature at embedding time — `construct_lean_representation`
+  in `corpus/build_cuvs.py` emits a header-prefixed template, *not* a bare
+  natural-language summary.
+
+---
+
+## 8. Open questions / data we still need
+
+- [ ] Pull `experiments/blueprint_matching/q*.txt` and translate to the same
+      metric language (nDCG@10, Recall@10) for an apples-to-apples row in a
+      results table.
+- [ ] Run MathlibQR (810 fair queries) against `/graph/embedding` with
+      `types=` restricted to Lean kinds — gives us the one number we are
+      currently missing to make a fair head-to-head row.
+- [ ] Decide whether to build a premise-group benchmark from `formal_dependency`,
+      or to evaluate against MathlibMPR directly (their ground truth is
+      Mathlib `decl_name`s, which our `formal_metadata.decl_name` matches by
+      construction — feasible).
+- [ ] Confirm which Mathlib revision our `formal_metadata` rows correspond
+      to. LSv2 pins v4.28.0-rc1; comparable-corpus claims need the same pin.
+- [ ] Exact size of LSv2's deployed corpus (not disclosed in paper; would
+      need to load their HF dataset).
+
+---
+
+## 9. References
+
+- LSv2 paper: arXiv:2605.13137 (v2, 2026-05-14). PDF at
+  `https://arxiv.org/pdf/2605.13137`.
+- LSv2 repo: `leansearch_v2_external/` (this directory). README is the
+  best single source; numbers in §6 verified from
+  `benchmark/MathlibQR.json` and `benchmark/MathlibMPR.json`.
+- LSv2 public deployment: `https://leansearch.net/search` (Qwen3-Reranker-**4B**
+  per README — paper Table 1 uses the 8B).
+- Our schema: `schema.md`. Sample rows: `samples.md`. Our API: `api/README.md`.

--- a/formalized_graph/docs/paper_writing/samples.md
+++ b/formalized_graph/docs/paper_writing/samples.md
@@ -1,0 +1,380 @@
+# Sample Records
+
+Two real rows per table, chosen so that the fields a paper most likely
+cites (embedding vectors, `lean` bridge annotations, decl names, etc.)
+are populated. Long text fields are truncated at
+~400 characters. Embedding vectors are shown as
+`<dim, norm, first 6, last 6>` rather than the full 4096 floats.
+
+## `paper`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `paper_id` | 000001c6-8298-4560-b04d-0536143afbd4 |
+| `kind` | paper |
+| `source` | arXiv |
+| `title` | Second-Order $\Gamma$-Limit for the Cahn-Hilliard Functional with Dirichlet Boundary Conditions, I |
+| `authors` | ['Irene Fonseca', 'Leonard Kreutz', 'Giovanni Leoni'] |
+| `url` | https://arxiv.org/pdf/2501.10452 |
+| `external_id` | 2501.10452 |
+| `categories` | ['math.AP'] |
+| `updated_at` | 2025-08-18 00:00:00+00:00 |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `paper_id` | 00000e4c-6c3a-48d1-9939-fed89c9d4f3b |
+| `kind` | paper |
+| `source` | arXiv |
+| `title` | The time evolution equation for advective heat transport as a constraint ⏎   for optimal bounds in Rayleigh-B\'enard convection |
+| `authors` | ['A. Tilgner'] |
+| `url` | https://arxiv.org/pdf/1812.09156 |
+| `external_id` | 1812.09156 |
+| `categories` | ['physics.flu-dyn'] |
+| `updated_at` | 2019-01-10 00:00:00+00:00 |
+
+## `arxiv_paper_metadata`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `arxiv_id` | 2105.05731 |
+| `journal_ref` | Acta Sci. Math. (Szeged) 86 (2020), no. 3-4, 667-670 |
+| `doi` | 10.14232/actasm-018-335-6 |
+| `license` | http://arxiv.org/licenses/nonexclusive-distrib/1.0/ |
+| `abstract` |   A result due to Williams, Stampfli and Fillmore shows that an essential ⏎ isometry $T$ on a Hilbert space $\mathcal{H}$ is a compact perturbation of an ⏎ isometry if and only if ind$(T)\le 0$. A recent result of S. Chavan yields an ⏎ analogous characterization of essential spherical isometries ⏎ $T=(T_1,\dots,T_n)\in\mathcal{B}(\mathcal{H})^n$ with ⏎ dim($\bigcap_{i=1}^n\ker(T_i))\le$ dim$(\bigcap_{i=1}^n… [+173 chars] |
+| `citation_count` | 0 |
+| `reference_ids` | ['DOI:10.14232/actasm-018-335-6', 'S2:d427e628491b7228ba061ffa53cd3e184e22a250'] |
+| `preamble` | \documentclass[12pt,a4paper]{amsart} ⏎ \usepackage{amsfonts} ⏎ \usepackage{amsthm} ⏎ \usepackage{amsmath} ⏎ \usepackage{amscd} ⏎ \usepackage[latin2]{inputenc} ⏎ \usepackage{t1enc} ⏎ \usepackage[mathscr]{eucal} ⏎ \usepackage{indentfirst} ⏎ \usepackage{graphicx} ⏎ \usepackage{graphics} ⏎ \usepackage{pict2e} ⏎ \usepackage{epic} ⏎ \usepackage{amssymb} ⏎ \usepackage{amstext} ⏎ \usepackage{ucs} ⏎ \usepackage[plainpages=false,pdfpagela… [+678 chars] |
+| `bibliography` | {"book": {"title": "J. Eschmeier and M. Putinar, Analytic sheaves and spectral decompositions, London Mathematical Monographs, New Series 10, Oxford University Press, New York(1996)."}, "FSW72": {"title": "P.A. Fillmore and J.G. Stampfli and J.P. Williams , On the essential numerical range, the essential spectrum, and a problem of Halmos, Acta Sci. Math. (Szeged) (1972), 179-192."}, "article": {"t… [+220 chars] |
+| `bibtex` | false |
+| `in_validation` | false |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `arxiv_id` | 2105.05736 |
+| `journal_ref` | NULL |
+| `doi` | NULL |
+| `license` | http://creativecommons.org/licenses/by/4.0/ |
+| `abstract` |   Negative sampling schemes enable efficient training given a large number of ⏎ classes, by offering a means to approximate a computationally expensive loss ⏎ function that takes all labels into account. In this paper, we present a new ⏎ connection between these schemes and loss modification techniques for ⏎ countering label imbalance. We show that different negative sampling schemes ⏎ implicitly trade-off… [+333 chars] |
+| `citation_count` | 12 |
+| `reference_ids` | ['ARXIV:2007.07314', 'DOI:10.18653/v1/2020.acl-main.209', 'ARXIV:2003.05176', 'ARXIV:2002.06298', 'ARXIV:1911.08731', 'ARXIV:1910.09217', 'DOI:10.1145/3298689.3346996', 'ARXIV:1907.10747', 'ARXIV:1906.07413', 'ARXIV:1904.05160', 'ARXIV:1901.05555', 'DOI:10.1515/cog-2017-0109', 'ARXIV:1810.11671', 'ARXIV:1810.07076', 'ARXIV:1802.04220', 'ARXIV:1712.00527', 'DOI:10.1109/TKDE.2017.2754499', 'ARXIV:1710.05381', 'ARXIV:1709.01450', 'ARXIV:1706.07881', 'ARXIV:1706.02677', 'DOI:10.1145/2983323.2983874', 'DOI:10.1145/2959100.2959190', 'DOI:10.1145/2939672.2939756', 'ARXIV:1512.03385', 'ARXIV:1511.06481', 'S2:f4c018bcc8ea707b83247866bdc8ccb87cd9f5da', 'DOI:10.1145/2623330.2623651', 'ARXIV:1310.4546', 'DOI:10.1145/2488388.2488391', 'DOI:10.1109/ICDM.2011.33', 'DOI:10.1109/TNN.2007.912312', 'DOI:10.1109/CVPR.2006.100', 'DOI:10.5555/1005332.1044701', 'DOI:10.17877/DE290R-3088', 'S2:4f582a003bc01f6cffeb3b6efb6fbcf8a2389245', 'DOI:10.1177/0049124189017003003', 'DOI:10.4018/978-1-5225-2255-3.CH159', 'DOI:10.4230/DagRep.8.7.62', 'S2:e0021d61c2ab1334bc725852edd44597f4c65dff', 'DOI:10.5555/2503308.2188396', 'ARXIV:1106.1813', 'S2:5eb1b872bd1ded1a293935697eb7f0af37bf6635'] |
+| `preamble` | \documentclass[11pt]{article} ⏎  ⏎ \usepackage{booktabs}  ⏎ \usepackage[normalem]{ulem} ⏎ \usepackage{authblk} ⏎  ⏎  ⏎ \usepackage[dvipsnames,usenames]{xcolor} ⏎  ⏎ \usepackage{url} ⏎  ⏎ \usepackage[colorlinks=true,citecolor=ForestGreen]{hyperref} ⏎  ⏎ \usepackage[left=1.25in, top=1in, bottom=1in, right=1.25in]{geometry} ⏎ \parskip 2.mm ⏎ \parindent 0.mm ⏎  ⏎ % ⏎ \title{Disentangling Sampling and Labeling Bias for Learning in Large-… [+9949 chars] |
+| `bibliography` | {"V18": {"title": "Manik Varma. Extreme classification repository. Website, 8 2018. http://manikvarma.org/downloads/XC/XMLRepository.html."}, "HeGa09": {"title": "Haibo He and Edwardo~A. Garcia. Learning from imbalanced data. IEEE Transactions on Knowledge and Data Engineering, 210 (9):0 1263--1284, 2009."}, "He:2016": {"title": "K.~He, X.~Zhang, S.~Ren, and J.~Sun. Deep residual learning for imag… [+11784 chars] |
+| `bibtex` | false |
+| `in_validation` | false |
+
+## `lean_community_paper_metadata`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `repo_slug` | emilyriehl/infinity-cosmos |
+| `branch` | main |
+| `src_path` | blueprint/src |
+| `preamble` | % In this file you should put the actual content of the blueprint. ⏎ % It will be used both by the web and the print version. ⏎ % It should *not* include the |
+| `bibliography` | {"HoTT:2013": {"title": "Homotopy Type Theory: Univalent Foundations of Mathematics"}, "Ara:2014hq": {"title": "Higher quasi-categories vs higher {R}ezk spaces"}, "BLV:2020af": {"title": "\\normalfont Adjoint functor theorems for homotopically enriched categories"}, "Day:1970oc": {"title": "On closed categories of functors"}, "Low:2013hb": {"title": "The homotopy bicategory of $(\\infty,1)$-catego… [+14937 chars] |
+| `bibtex` | true |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `repo_slug` | thefundamentaltheor3m/Sphere-Packing-Lean |
+| `branch` | main |
+| `src_path` | blueprint/src |
+| `preamble` | % This file makes a printable version of the blueprint ⏎ % It should include all the \usepackage needed for the pdf version. ⏎ % The template version assume you want to use a modern TeX compiler ⏎ % such as xeLaTeX or luaLaTeX including support for unicode ⏎ % and Latin Modern Math font with standard bugfixes applied. ⏎ % It also uses expl3 in order to support macros related to the dependency graph. ⏎ % It al… [+4159 chars] |
+| `bibliography` | {"Ma": {"title": "Manin, Yu. I., Real multiplication and noncommutative geometry (ein Alterstraum). The legacy of Niels Henrik Abel, 685-727, Springer, Berlin, 2004. %"}, "BRV": {"title": "A. Bondarenko, D. Radchenko, M. Viazovska, On optimal asymptotic bounds for spherical designs, Annals of Math. 178 (2)(2013), pp. 443--452."}, "Lee": {"title": "S. Lee, Algebraic proof of modular form inequaliti… [+4838 chars] |
+| `bibtex` | false |
+
+## `lean_repo_metadata`
+
+_(no matching sample row)_
+
+## `statement`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `statement_id` | f7577c7e-c2c1-40a4-881d-101d90a0bc33 |
+| `paper_id` | 3b740cc9-1f7c-45b0-8603-bb66136cf421 |
+| `formality` | informal |
+| `kind` | proposition |
+| `body` | Let $\mathcal I\subseteq 2^{D}$ be a family of index sets such that $\set{m_I\colon I\in\mathcal I}$ is a valid set of cross-moments. The maximum entropy distribution having the specified cross-moments has the form $\centering{\colorbox{Yellow}{\parbox{0.9\textwidth}{}}}\flushleft{}(\v \gamma)=\exp(\sum_{I\in \mathcal I}a_I\prod_{i\in I}\gamma_i)/ [\sum_{\v\gamma\in\mathbb{B}^{d}}\exp(\sum_{I\in \… [+39 chars] |
+| `proof` | Define the Lagrange multipliers $L(\pi,\v a)=\sum_{I\in \mathcal I}a_{I}[\sum_{\v\gamma\in\mathbb{B}^{d}}\pi(\v\gamma)\prod_{i\in I}\gamma_i-m_I]$ and differentiate $\partial[H(\pi)+L(\pi,\v a)]/\partial \pi(\v\gamma)=-\log[\pi(\v\gamma)]-1+\sum_{I\in \mathcal I}a_{I}\prod_{i\in I}\gamma_i$. Solving the first order condition and normalizing completes the proof. |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `statement_id` | c731122f-2b99-4497-ae0e-e814994a8300 |
+| `paper_id` | 2f5fd1d1-8e18-435f-a048-3d00c6e50f15 |
+| `formality` | formal |
+| `kind` | instance |
+| `body` | Lean.instInhabitedStructureInfo : Inhabited Lean.StructureInfo |
+| `proof` | NULL |
+
+## `informal_metadata`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `statement_id` | d09e4d5d-42f1-4c1c-9b43-b872354e3271 |
+| `ordinal` | 8 |
+| `ref` | 2.1 |
+| `label` | dissociated |
+| `note` | Dissociation |
+| `pre_context` | ] ⏎ This follows by the triangle inequality applied $k$ times if we knew that, for $1\leq l\leq k$, ⏎ \[\lvert \tau_{t_1+\cdots+t_l}F(x)-\tau_{t_1+\cdots+t_{l-1}}F(x)\rvert \leq \epsilon/k.\] ⏎ We can write the left-hand side as ⏎ \[\lvert \tau_{t_1+\cdots+t_l}F(x)-\tau_{t_1+\cdots+t_{l-1}}F(x)\rvert=\lvert \tau_{t_l}F(x-t_1-\cdots-t-{l-1})-F(x-t_1-\cdots-t-{l-1})\rvert.\] ⏎ The right-hand side is at most ⏎ \… [+98 chars] |
+| `post_context` | NULL |
+| `lean` | AddDissociated |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `statement_id` | cd29da73-0d65-437e-ac2f-8ad9d080eea8 |
+| `ordinal` | 0 |
+| `ref` | 1.1 |
+| `label` | mzi |
+| `note` | Marcinkiewicz-Zygmund inequality |
+| `pre_context` | \declaretheorem[sibling=theorem]{lemma} ⏎ \declaretheorem[sibling=theorem]{definition} ⏎ \declaretheorem[sibling=theorem]{example} ⏎  ⏎  ⏎ \newcommand{\proves}[1]{} ⏎ \newcommand{\lean}[1]{} ⏎ \newcommand{\leanok}{} ⏎  ⏎  ⏎  ⏎ \ExplSyntaxOn ⏎ \NewDocumentCommand{\uses}{m} ⏎  {\clist_map_inline:nn{#1}{\vphantom{\ref{##1}}} ⏎   \ignorespaces} ⏎ \ExplSyntaxOff ⏎  ⏎ \title{Arithmetic Progressions - Almost Periodicity} ⏎ \author{Thomas B… [+97 chars] |
+| `post_context` | NULL |
+| `lean` | Real.marcinkiewicz_zygmund', Real.marcinkiewicz_zygmund |
+
+## `formal_metadata`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `statement_id` | 12489b59-390a-408d-b696-bafea34a4a2d |
+| `file_path` | Init/Prelude.lean |
+| `decl_name` | Inhabited |
+| `module` | Init.Prelude |
+| `docstring` | `Inhabited α` is a typeclass that says that `α` has a designated element, ⏎ called `(default : α)`. This is sometimes referred to as a "pointed type". ⏎  ⏎ This class is used by functions that need to return a value of the type ⏎ when called "out of domain". For example, `Array.get! arr i : α` returns ⏎ a value of type `α` when `arr : Array α`, but if `i` is not in range of ⏎ the array, it reports a panic mes… [+180 chars] |
+| `is_instance` | false |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `statement_id` | 6dfeee02-3f8b-4bde-a50a-c7949067989a |
+| `file_path` | Lean/Structure.lean |
+| `decl_name` | Lean.StructureInfo |
+| `module` | Lean.Structure |
+| `docstring` | Data about a type created with the `structure` command. ⏎  |
+| `is_instance` | false |
+
+## `informal_dependency`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `src_id` | 51cf8c08-c1ad-486c-86c6-7068274dd864 |
+| `location` | pre_context |
+| `cite_id` | 3361f9e6-4504-447f-a3ac-68115acf6dca |
+| `cite_key` | LW1 |
+| `dep_id` | 0a5fd1d5-7f13-4847-a580-34319f86847c |
+| `dep_key` | LW1\|the following |
+| `dep_name` | Theorem 6 |
+| `methods` | ['heuristic'] |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `src_id` | d43e6a0a-7efd-4214-8da1-fa6208af903d |
+| `location` | post_context |
+| `cite_id` | 9bea1ad0-9ae8-4cee-9cf9-c921fb2cbb5e |
+| `cite_key` | lin |
+| `dep_id` | 240cfcc5-e29c-47b0-b40b-fa3a8caee2e1 |
+| `dep_key` | lin\|in view of |
+| `dep_name` | Theorem 1.4 |
+| `methods` | ['heuristic'] |
+
+## `formal_dependency`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `src_id` | c731122f-2b99-4497-ae0e-e814994a8300 |
+| `dep_id` | 12489b59-390a-408d-b696-bafea34a4a2d |
+| `edge_type` | sig |
+| `tactic_context` | NULL |
+| `position` | conclusion |
+| `binder` | explicit |
+| `role` | fn |
+| `via_proj` | false |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `src_id` | c731122f-2b99-4497-ae0e-e814994a8300 |
+| `dep_id` | 6dfeee02-3f8b-4bde-a50a-c7949067989a |
+| `edge_type` | sig |
+| `tactic_context` | NULL |
+| `position` | conclusion |
+| `binder` | explicit |
+| `role` | arg |
+| `via_proj` | false |
+
+## `notation`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `notation_id` | 4bec4b96-de57-4bfc-a81f-54bfddb43a98 |
+| `statement_id` | bbe813e1-276a-482b-8162-0c4235f0c0b4 |
+| `pattern` | Q_0 |
+| `description` | null forms Q_0 and Q_{\alpha, \beta} |
+| `created_at` | 2026-05-11 22:40:10.162610+00:00 |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `notation_id` | ba461d35-0397-414e-acf5-6ea8e4c88c94 |
+| `statement_id` | bbe813e1-276a-482b-8162-0c4235f0c0b4 |
+| `pattern` | Q_{\\alpha, \\beta} |
+| `description` | null forms Q_{\alpha, \beta} |
+| `created_at` | 2026-05-11 22:40:10.162610+00:00 |
+
+## `slogan_prompt`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `name` | formal |
+| `template` | {# budget: 4000 #} ⏎ Write a 1-3 sentence, plain-English standalone summary of the following Lean mathematical declaration. ⏎ Use ASCII characters only — no LaTeX, no Unicode math. ⏎ Describe what the declaration says without referring to it as "this theorem" / "this declaration". ⏎  ⏎ {{ target_block }} ⏎  ⏎ {% if deps_text %} ⏎ Related context ({{ deps_included }}/{{ deps_available }} dependencies): ⏎ {{ deps_tex… [+17 chars] |
+| `created_at` | 2026-05-19 07:04:29.434162+00:00 |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `name` | minimal |
+| `template` | Write a 1-4 sentence, plain-English standalone summary of the following mathematical statement. ⏎ Use words in ASCII characters only, no LaTeX or Unicode. ⏎ Describe the result without referencing it as "this statement" or similar. ⏎ If you believe this is insufficient context to summarise this statement, respond with exactly "INSUFFICIENT CONTEXT: " followed by a short reason. ⏎  ⏎ {{ statement.kind \| titl… [+84 chars] |
+| `created_at` | 2026-05-13 20:12:17.245489+00:00 |
+
+## `slogan_model`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `name` | qwen3-235b |
+| `model` | Qwen/Qwen3-235B-A22B-Instruct-2507 |
+| `temperature` | 0.3 |
+| `max_tokens` | 256 |
+| `created_at` | 2026-05-11 06:13:24.948887+00:00 |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `name` | pilot-claude-sonnet-4-6 |
+| `model` | claude-sonnet-4-6 |
+| `temperature` | NULL |
+| `max_tokens` | 600 |
+| `created_at` | 2026-05-13 23:20:24.799664+00:00 |
+
+## `slogan`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `slogan_id` | 01f49b12-67d2-4bc2-833f-3aa3dd0d1915 |
+| `statement_id` | cd29da73-0d65-437e-ac2f-8ad9d080eea8 |
+| `prompt_name` | minimal |
+| `model_name` | qwen3-235b |
+| `slogan` | For a function f with average value zero and absolute value at most 2, the expected value of the 2m-th power of the sum of n independent copies of f is at most (4mn) raised to the power m. |
+| `in_tokens` | 208 |
+| `out_tokens` | 49 |
+| `created_at` | 2026-05-13 20:12:32.594649+00:00 |
+| `insufficient_context` | false |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `slogan_id` | 828739f1-6cae-4366-b6d9-930997d7c4d3 |
+| `statement_id` | c731122f-2b99-4497-ae0e-e814994a8300 |
+| `prompt_name` | formal |
+| `model_name` | qwen3-235b |
+| `slogan` | Lean.StructureInfo has a default value defined because it is an inhabited type, meaning a valid instance can always be returned even in cases where no specific data is available. This default value helps prevent errors in programs that require a structure info object. The type contains data about structure fields and parent types in Lean. |
+| `in_tokens` | 268 |
+| `out_tokens` | 63 |
+| `created_at` | 2026-05-23 04:18:45.342251+00:00 |
+| `insufficient_context` | false |
+
+## `embedding_model`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `name` | qwen3-8b |
+| `model` | Qwen/Qwen3-Embedding-8B |
+| `instruction` | Represent the given math statement for retrieving related statements by natural language query. ⏎  |
+| `dim` | 4096 |
+| `normalized` | true |
+| `created_at` | 2026-05-15 06:34:38.106587+00:00 |
+
+## `embedding`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `embedding_id` | 71cd7c7f-223e-4f3b-9f1d-e178ff9e91a6 |
+| `slogan_id` | 00060ea1-b1e0-437c-bde2-f69352baa700 |
+| `model_name` | qwen3-8b |
+| `embedding` | <dim=4096 norm=1.0000 head=[-0.0083, +0.0022, +0.0036, -0.0265, +0.0028, +0.0162] tail=[+0.0099, -0.0080, +0.0219, -0.0107, -0.0074, -0.0036]> |
+| `created_at` | 2026-05-15 06:34:59.988999+00:00 |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `embedding_id` | fdf77896-b579-483f-b7a1-dd75f58bc71b |
+| `slogan_id` | 0013f294-d4d6-4f9c-9b3a-d0d6e41d5551 |
+| `model_name` | qwen3-8b |
+| `embedding` | <dim=4096 norm=1.0000 head=[+0.0477, +0.0025, +0.0008, -0.0203, -0.0052, +0.0107] tail=[+0.0168, -0.0190, -0.0118, +0.0028, -0.0043, +0.0054]> |
+| `created_at` | 2026-05-15 06:34:59.988999+00:00 |
+
+## `arxiv_parse_status`
+
+**row 1**
+
+| field | value |
+|---|---|
+| `arxiv_id` | 2406.00228 |
+| `last_parse_attempt_at` | 2026-04-13 23:31:03.276143+00:00 |
+| `error` | NULL |
+| `parsing_method` | regex |
+| `validation_level` | statement |
+
+**row 2**
+
+| field | value |
+|---|---|
+| `arxiv_id` | 2308.12297 |
+| `last_parse_attempt_at` | 2026-04-12 05:14:43.368742+00:00 |
+| `error` | [EMPTY ERROR] No statements found |
+| `parsing_method` | regex |
+| `validation_level` | statement |

--- a/formalized_graph/docs/paper_writing/schema.md
+++ b/formalized_graph/docs/paper_writing/schema.md
@@ -1,0 +1,225 @@
+# RDS Schema (database `v2`, schema `public`)
+
+Reference for paper writing. Tables documented in the order data flows:
+**papers → statements → metadata → slogans → embeddings**, with edge
+tables alongside the metadata they annotate.
+
+Connection: `theorem-search.cluster-cx0ei6kq0qcn.us-west-2.rds.amazonaws.com:5432`,
+db `v2`, user `postgres` (credentials in `.env` via Secrets Manager).
+
+## `paper`  (1,841,292 rows)
+
+Source-paper registry. One row per paper/repo/blueprint, regardless of source. `kind` distinguishes paper-style records. `external_id` is the natural key on its source (arxiv id, repo slug, etc).
+
+| column | type | null |
+|---|---|---|
+| `paper_id` | `uuid` | no |
+| `kind` | `paper_kind` | no |
+| `source` | `text` | yes |
+| `title` | `text` | no |
+| `authors` | `text[]` | no |
+| `url` | `text` | yes |
+| `external_id` | `text` | yes |
+| `categories` | `text[]` | no |
+| `updated_at` | `timestamptz` | yes |
+
+## `arxiv_paper_metadata`  (1,841,240 rows)
+
+arXiv-specific metadata, keyed by `arxiv_id` (which equals `paper.external_id` for arXiv rows). Holds abstract, bibliography (jsonb keyed by cite_key), parsed preamble, and reference graph. `in_validation` flags rows still being checked.
+
+| column | type | null |
+|---|---|---|
+| `arxiv_id` | `text` | no |
+| `journal_ref` | `text` | yes |
+| `doi` | `text` | yes |
+| `license` | `text` | yes |
+| `abstract` | `text` | yes |
+| `citation_count` | `int4` | yes |
+| `reference_ids` | `text[]` | yes |
+| `preamble` | `text` | yes |
+| `bibliography` | `jsonb` | yes |
+| `bibtex` | `bool` | yes |
+| `in_validation` | `bool` | no |
+
+## `lean_community_paper_metadata`  (21 rows)
+
+Blueprint-project metadata for Lean community repos that ship a LaTeX blueprint (apap, pfr, carleson, sphere-packing, etc.). `src_path` is the blueprint TeX root inside the repo.
+
+| column | type | null |
+|---|---|---|
+| `repo_slug` | `text` | no |
+| `branch` | `text` | no |
+| `src_path` | `text` | no |
+| `preamble` | `text` | yes |
+| `bibliography` | `jsonb` | yes |
+| `bibtex` | `bool` | yes |
+
+## `lean_repo_metadata`  (30 rows)
+
+Lean repo build pins — toolchain, mathlib revision, git commit. Used to reproduce the formalization environment that produced `formal_metadata` rows.
+
+| column | type | null |
+|---|---|---|
+| `repo_slug` | `text` | no |
+| `repo_url` | `text` | yes |
+| `lean_toolchain` | `text` | yes |
+| `mathlib_rev` | `text` | yes |
+| `git_commit` | `text` | yes |
+
+## `statement`  (12,137,642 rows)
+
+Core node table. Every theorem/lemma/definition/remark, formal or informal. `body` is the verbatim text (LaTeX for informal, Lean source for formal). `proof` is informal-only.
+
+| column | type | null |
+|---|---|---|
+| `statement_id` | `uuid` | no |
+| `paper_id` | `uuid` | no |
+| `formality` | `formality_kind` | no |
+| `kind` | `text` | no |
+| `body` | `text` | no |
+| `proof` | `text` | yes |
+
+## `informal_metadata`  (11,749,537 rows)
+
+Informal-side per-statement metadata. **`lean` is the blueprint `\lean{...}` annotation** — when populated it is the ground-truth bridge to one or more formal `decl_name`s (comma-separated). `pre_context`/`post_context` are the surrounding paragraph windows used by some slogan prompts.
+
+| column | type | null |
+|---|---|---|
+| `statement_id` | `uuid` | no |
+| `ordinal` | `int4` | no |
+| `ref` | `text` | yes |
+| `label` | `text` | yes |
+| `note` | `text` | yes |
+| `pre_context` | `text` | yes |
+| `post_context` | `text` | yes |
+| `lean` | `text` | yes |
+
+## `formal_metadata`  (388,105 rows)
+
+Formal-side per-statement metadata. `decl_name` is the fully-qualified Lean name — the natural key when matching to `informal_metadata.lean`. `is_instance` flags `instance` declarations.
+
+| column | type | null |
+|---|---|---|
+| `statement_id` | `uuid` | no |
+| `file_path` | `text` | yes |
+| `decl_name` | `text` | yes |
+| `module` | `text` | yes |
+| `docstring` | `text` | yes |
+| `is_instance` | `bool` | no |
+
+## `informal_dependency`  (18,321,208 rows)
+
+Informal edges. Each row is a (`src_id` → `dep_id`/`cite_id`) reference detected in the source paper. `methods` records *how* it was detected (deterministic / heuristic / LLM / judge); used by the `comprehensive` slogan prompt as a trust score.
+
+| column | type | null |
+|---|---|---|
+| `src_id` | `uuid` | no |
+| `location` | `text` | no |
+| `cite_id` | `uuid` | yes |
+| `cite_key` | `text` | yes |
+| `dep_id` | `uuid` | yes |
+| `dep_key` | `text` | yes |
+| `dep_name` | `text` | yes |
+| `methods` | `text[]` | no |
+
+## `formal_dependency`  (11,335,708 rows)
+
+Formal edges from Lean's elaborator. `edge_type` ∈ {def, proof, sig}: signature edges live in the type; def/proof edges live in the body. `position`/`binder`/`role` annotate signature edges (used by the ranker to prioritize structural args).
+
+| column | type | null |
+|---|---|---|
+| `src_id` | `uuid` | no |
+| `dep_id` | `uuid` | no |
+| `edge_type` | `text` | no |
+| `tactic_context` | `text` | yes |
+| `position` | `text` | yes |
+| `binder` | `text` | yes |
+| `role` | `text` | yes |
+| `via_proj` | `bool` | yes |
+
+## `notation`  (23,017,529 rows)
+
+Per-statement notation glossary (LaTeX pattern → English description). Generated downstream of slogan creation; used by retrieval to disambiguate symbols.
+
+| column | type | null |
+|---|---|---|
+| `notation_id` | `uuid` | no |
+| `statement_id` | `uuid` | no |
+| `pattern` | `text` | no |
+| `description` | `text` | no |
+| `created_at` | `timestamptz` | no |
+
+## `slogan_prompt`  (8 rows)
+
+Immutable prompt-template registry. `slogan.prompt_name` foreign-keys here. Each template is a Jinja string consumed by the slogan generator.
+
+| column | type | null |
+|---|---|---|
+| `name` | `text` | no |
+| `template` | `text` | no |
+| `created_at` | `timestamptz` | no |
+
+## `slogan_model`  (2 rows)
+
+LLM registry for slogan generation. `slogan.model_name` foreign-keys here.
+
+| column | type | null |
+|---|---|---|
+| `name` | `text` | no |
+| `model` | `text` | no |
+| `temperature` | `float8` | yes |
+| `max_tokens` | `int4` | yes |
+| `created_at` | `timestamptz` | no |
+
+## `slogan`  (16,468,862 rows)
+
+The natural-language summary attached to a `statement` by (`prompt_name`, `model_name`). One statement can have many slogans (different prompts/models). `insufficient_context=true` means the LLM refused — these are excluded from embedding and matching.
+
+| column | type | null |
+|---|---|---|
+| `slogan_id` | `uuid` | no |
+| `statement_id` | `uuid` | no |
+| `prompt_name` | `text` | no |
+| `model_name` | `text` | no |
+| `slogan` | `text` | no |
+| `in_tokens` | `int4` | yes |
+| `out_tokens` | `int4` | yes |
+| `created_at` | `timestamptz` | no |
+| `insufficient_context` | `bool` | no |
+
+## `embedding_model`  (1 rows)
+
+Embedding-model registry. `instruction` is prepended to slogan text at embed time (Qwen3 retrieval prefix). `dim` is the native dimensionality (4096 for qwen3-8b).
+
+| column | type | null |
+|---|---|---|
+| `name` | `text` | no |
+| `model` | `text` | no |
+| `instruction` | `text` | yes |
+| `dim` | `int4` | no |
+| `normalized` | `bool` | no |
+| `created_at` | `timestamptz` | no |
+
+## `embedding`  (12,137,638 rows)
+
+The vector store. One row per (`slogan_id`, `model_name`). `embedding` is `vector(4096)` for qwen3-8b. Indexed by binary-quantized HNSW (`bit(4096)`) for shortlist search and queried with cosine (`<=>`) for full-precision rerank.
+
+| column | type | null |
+|---|---|---|
+| `embedding_id` | `uuid` | no |
+| `slogan_id` | `uuid` | no |
+| `model_name` | `text` | no |
+| `embedding` | `vector` | no |
+| `created_at` | `timestamptz` | no |
+
+## `arxiv_parse_status`  (1,841,240 rows)
+
+Per-arXiv parse-attempt log. `error` is NULL on success, otherwise a tagged reason ([EMPTY ERROR] for documents that parsed but yielded no statements). `parsing_method` is the parser used.
+
+| column | type | null |
+|---|---|---|
+| `arxiv_id` | `text` | no |
+| `last_parse_attempt_at` | `timestamptz` | no |
+| `error` | `text` | yes |
+| `parsing_method` | `text` | no |
+| `validation_level` | `text` | no |


### PR DESCRIPTION
## Summary

- New `formalized_graph/docs/paper_writing/` directory: a "second brain" of paper-relevant context so future sessions can ground themselves without re-deriving facts from the live system.
- Contents: `schema.md` (v2 RDS table schemas), `samples.md` (two real rows per table with embeddings rendered compactly), `api_reference.md` (thin pointer to the canonical `api/README.md` + legacy-`/search`-vs-`/graph/*` ID gotcha), `leansearch_v2_comparison.md` (working notes vs. LeanSearch v2), and a `README.md` with a contributor prompt.
- `.gitignore`: exclude `formalized_graph/docs/paper_writing/leansearch_v2_external/` — that's a local clone of the LSv2 repo used as a reference, not vendored.

## Test plan

- [ ] Confirm rendered Markdown looks right on GitHub (tables, internal links resolve).
- [ ] Confirm `../../../api/README.md` link in `api_reference.md` resolves to the canonical API doc.
- [ ] No code changes — nothing to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)