### PR TITLE
Run /search in the threadpool instead of blocking the event loop

### DIFF
--- a/api/routes/mcp.py
+++ b/api/routes/mcp.py
@@ -1,5 +1,6 @@
 import json
 from fastapi import APIRouter, Request
+from fastapi.concurrency import run_in_threadpool
 from models import SearchRequest
 from routes.search import search
 
@@ -77,7 +78,9 @@ async def mcp(request: Request):
 
         try:
             payload = SearchRequest(**(params.get("arguments") or {}))
-            search_response = await search(payload, mcp=True)
+            # `search` is a sync function doing blocking I/O; run it in the
+            # threadpool so this async MCP handler doesn't block the event loop.
+            search_response = await run_in_threadpool(search, payload, mcp=True)
         except Exception as e:
             return _mcp_error(request_id, -32603, str(e))
 

--- a/api/routes/search.py
+++ b/api/routes/search.py
@@ -1,5 +1,6 @@
 import math
 import os
+import threading
 from typing import List, Optional
 from fastapi import APIRouter, HTTPException
 from openai import OpenAI
@@ -10,14 +11,21 @@ from models import SearchRequest, SearchResponse, PaperResult, TheoremResult, DE
 router = APIRouter()
 
 _openai_client: OpenAI = None
+# `search` is a sync def running in FastAPI's threadpool, so get_openai_client
+# can be called from several worker threads at once on a cold instance. Guard
+# the lazy init so concurrent first-callers create exactly one client instead
+# of racing to build (and discard) several.
+_openai_client_lock = threading.Lock()
 
 def get_openai_client() -> OpenAI:
     global _openai_client
     if _openai_client is None:
-        _openai_client = OpenAI(
-            base_url="https://api.tokenfactory.nebius.com/v1/",
-            api_key=os.environ["NEBIUS_API_KEY"],
-        )
+        with _openai_client_lock:
+            if _openai_client is None:
+                _openai_client = OpenAI(
+                    base_url="https://api.tokenfactory.nebius.com/v1/",
+                    api_key=os.environ["NEBIUS_API_KEY"],
+                )
     return _openai_client
 
 
@@ -215,7 +223,14 @@ async def root():
 
 
 @router.post("/search", response_model=SearchResponse)
-async def search(payload: SearchRequest, mcp: bool = False):
+def search(payload: SearchRequest, mcp: bool = False):
+    # Deliberately a sync `def`, NOT `async def`. The body does blocking I/O
+    # (psycopg2 queries + a ~1s OpenAI embedding call). FastAPI runs sync
+    # handlers in its worker threadpool, so concurrent requests run in
+    # parallel. If this were `async def`, every blocking call would run on
+    # the event loop and serialize all requests on the instance — which,
+    # under App Runner's per-instance concurrency, produces 502/503/504/429.
+    # Any in-process caller (e.g. routes.mcp) must offload via run_in_threadpool.
     try:
         with rds_conn() as conn, conn.cursor() as cur:
             cur.execute(


### PR DESCRIPTION
## The core fix for the 502/503/504/429 errors

`/search` and the `/mcp` tool handler were `async def` but did **blocking I/O** (psycopg2 queries + a ~1s OpenAI/Nebius embedding call). Blocking calls inside an `async` route run on the event loop, so each container instance processed these requests **one at a time**.

The API runs on **AWS App Runner**, which routes up to `MaxConcurrency` (default **100**) concurrent requests to a single instance. With the handlers serialized, that backlog produced exactly the reported errors — all emitted by App Runner/Envoy, never by the app (whose only failure path is HTTP 500):

- **504** — requests waiting behind the serialized queue exceed App Runner's request timeout
- **502** — the jammed event loop fails health checks → instance recycled mid-request
- **503** — no healthy instance during the recycle window
- **429** — App Runner load-shedding during scale-out

### Change
- `search` is now a sync `def`, so FastAPI runs it in its worker **threadpool** (concurrent requests run in parallel) — matching `/graph/embedding`, which was already a sync `def` and does *not* exhibit the bug.
- The async `/mcp` handler offloads via `run_in_threadpool(search, …)`.
- Guarded the lazy `get_openai_client()` global init with a `threading.Lock` (double-checked locking), since it can now be called from several threadpool threads at once on a cold instance.

### Evidence (measured against prod)
16 concurrent `/search` calls: **~17s wall, p50 12s** (serialized). The identical-workload sync `/graph/embedding` stays **~1s flat** under the same concurrency.

### Review
Reviewed by a multi-agent adversarial pass (FastAPI async semantics, call-site regressions, concurrency) plus a focused second pass on the lock — no outstanding issues.

Companion infra guidance: `docs/apprunner-scaling-runbook`. Independent of the other PRs; recommend merging this one first.