### PR TITLE
Make DB connection-pool size configurable via env

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -1,5 +1,6 @@
 import os
 import json
+import logging
 import boto3
 from contextlib import contextmanager
 from functools import lru_cache
@@ -8,15 +9,55 @@ from psycopg2 import OperationalError
 from psycopg2.pool import ThreadedConnectionPool
 
 
+logger = logging.getLogger(__name__)
+
 _conn_pools: dict[str, ThreadedConnectionPool] = {}
 
+
+def _env_int(name: str, default: int) -> int:
+    """Positive int from the environment, falling back to `default` when the
+    var is unset, blank, non-numeric, or non-positive. A non-empty but invalid
+    value is logged so a misconfigured deploy is diagnosable instead of
+    silently running on the default."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an integer; using default %d", name, raw, default)
+        return default
+    if val <= 0:
+        logger.warning("%s=%d must be positive; using default %d", name, val, default)
+        return default
+    return val
+
+
 # Caps any single query at 10s — runaway queries would otherwise pin a
-# connection forever and eventually deadlock the pool.
-_STATEMENT_TIMEOUT_MS = 10_000
-# Match FastAPI's default sync threadpool size so threads don't queue on
+# connection forever and eventually deadlock the pool. Override with
+# RDS_STATEMENT_TIMEOUT_MS.
+_STATEMENT_TIMEOUT_MS = _env_int("RDS_STATEMENT_TIMEOUT_MS", 10_000)
+
+# Per-process connection-pool bounds. The default max (40) matches FastAPI's
+# default sync threadpool size so threadpool workers don't queue on
 # getconn() once route handlers are sync def.
-_POOL_MIN = 5
-_POOL_MAX = 40
+#
+# CONNECTION BUDGET: each running instance opens up to _POOL_MAX connections
+# per distinct dbname. On AWS App Runner the service scales to `MaxSize`
+# instances, so the worst-case connection count against the Aurora cluster is
+# roughly:  MaxSize × _POOL_MAX × (distinct dbnames in use).  Keep that product
+# safely under the cluster's max_connections (Aurora derives it from the
+# instance class) or front the cluster with RDS Proxy. Tune per instance via
+# RDS_POOL_MIN / RDS_POOL_MAX without a code change.
+_POOL_MIN = _env_int("RDS_POOL_MIN", 5)
+_POOL_MAX = _env_int("RDS_POOL_MAX", 40)
+# ThreadedConnectionPool requires minconn <= maxconn; clamp on misconfig.
+if _POOL_MIN > _POOL_MAX:
+    logger.warning(
+        "RDS_POOL_MIN (%d) > RDS_POOL_MAX (%d); clamping min down to max",
+        _POOL_MIN, _POOL_MAX,
+    )
+    _POOL_MIN = _POOL_MAX
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Why
The per-process connection pool was hard-coded to `min=5 / max=40`. Each running instance opens up to `max` connections **per dbname**, and on App Runner the service scales to `MaxSize` instances, so worst-case connections to the Aurora cluster are:

```
MaxSize × pool_max × (#dbnames)
```

There was no way to tune this against the cluster's `max_connections` (or cap it when fronting with RDS Proxy) without a code change.

## Change
- `RDS_POOL_MIN` / `RDS_POOL_MAX` / `RDS_STATEMENT_TIMEOUT_MS` are now env-configurable via a small `_env_int` helper.
- **Defaults are unchanged** (5 / 40 / 10000) — no behavior change unless the env vars are set.
- `min` is clamped to `max` on misconfiguration; invalid/clamped values are logged as warnings so a bad deploy is diagnosable instead of silently falling back.
- Documents the Aurora connection-budget math inline.

## Review
Multi-agent adversarial review found no bugs (the `_env_int` edge cases — blank/non-numeric/negative/zero/min>max — all resolve to a valid `(minconn, maxconn)`).

Independent of the other PRs. The env vars are referenced by the `docs/apprunner-scaling-runbook` PR.